### PR TITLE
feat(ui): add item count indicators for collapsed JSON nodes

### DIFF
--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -47,18 +47,25 @@ const JsonViewer: React.FC<JsonViewerProps> = ({
       <span>
         <span className="text-gray-400 select-none">
           {isCollapsible && (
-            <button
-              onClick={() => setIsCollapsed(!isCollapsed)}
-              className="hover:bg-gray-200 rounded p-1 focus:outline-none"
-            >
-              {isCollapsed ? (
-                <ChevronRight className="w-3 h-3 inline" />
-              ) : (
-                <ChevronDown className="w-3 h-3 inline" />
+            <>
+              <button
+                onClick={() => setIsCollapsed(!isCollapsed)}
+                className="hover:bg-gray-200 rounded p-1 focus:outline-none"
+              >
+                {isCollapsed ? (
+                  <ChevronRight className="w-3 h-3 inline" />
+                ) : (
+                  <ChevronDown className="w-3 h-3 inline" />
+                )}
+              </button>
+              {isCollapsed && (
+                <span className="text-xs text-gray-500 mr-1">
+                  {data.length} {data.length === 1 ? "item" : "items"}
+                </span>
               )}
-            </button>
+            </>
           )}
-          [
+          [{isCollapsed ? "..." : ""}
         </span>
         {!isCollapsed && (
           <>
@@ -93,18 +100,26 @@ const JsonViewer: React.FC<JsonViewerProps> = ({
       <span>
         <span className="text-gray-400 select-none">
           {isCollapsible && (
-            <button
-              onClick={() => setIsCollapsed(!isCollapsed)}
-              className="hover:bg-gray-200 rounded p-1 focus:outline-none"
-            >
-              {isCollapsed ? (
-                <ChevronRight className="w-3 h-3 inline" />
-              ) : (
-                <ChevronDown className="w-3 h-3 inline" />
+            <>
+              <button
+                onClick={() => setIsCollapsed(!isCollapsed)}
+                className="hover:bg-gray-200 rounded p-1 focus:outline-none"
+              >
+                {isCollapsed ? (
+                  <ChevronRight className="w-3 h-3 inline" />
+                ) : (
+                  <ChevronDown className="w-3 h-3 inline" />
+                )}
+              </button>
+              {isCollapsed && (
+                <span className="text-xs text-gray-500 mr-1">
+                  {entries.length} {entries.length === 1 ? "key" : "keys"}
+                </span>
               )}
-            </button>
+            </>
           )}
           {"{"}
+          {isCollapsed ? "..." : ""}
         </span>
         {!isCollapsed && (
           <>


### PR DESCRIPTION
- Display count of items/keys next to collapsed arrays and objects
- Show "X items" for arrays and "X keys" for objects
- Use singular form for single items/keys
- Style indicators with smaller gray text for subtle appearance

Improves data visualization by providing immediate insight into node contents without requiring expansion.